### PR TITLE
implement method to save fax with metadata locally

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1820,6 +1820,11 @@
         "verror": "1.10.0"
       }
     },
+    "kareem": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/kareem/-/kareem-2.3.0.tgz",
+      "integrity": "sha512-6hHxsp9e6zQU8nXsP+02HGWXwTkOEw6IROhF2ZA28cYbUk4eJ6QbtZvdqZOdD9YPKghG3apk5eOCvs+tLl3lRg=="
+    },
     "lazystream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.0.tgz",
@@ -2518,6 +2523,78 @@
         "saslprep": "^1.0.0"
       }
     },
+    "mongoose": {
+      "version": "5.6.9",
+      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-5.6.9.tgz",
+      "integrity": "sha512-NRW5UJSmwyJxK+MRHmq+dQKgZqMZCpW1aPkpBZESqrrgF2J15Flo/4K3RYkSSQY7oKhfbgqZTPo+J1snJ3hJ3w==",
+      "requires": {
+        "async": "2.6.2",
+        "bson": "~1.1.1",
+        "kareem": "2.3.0",
+        "mongodb": "3.2.7",
+        "mongodb-core": "3.2.7",
+        "mongoose-legacy-pluralize": "1.0.2",
+        "mpath": "0.6.0",
+        "mquery": "3.2.1",
+        "ms": "2.1.2",
+        "regexp-clone": "1.0.0",
+        "safe-buffer": "5.1.2",
+        "sift": "7.0.1",
+        "sliced": "1.0.1"
+      },
+      "dependencies": {
+        "async": {
+          "version": "2.6.2",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.6.2.tgz",
+          "integrity": "sha512-H1qVYh1MYhEEFLsP97cVKqCGo7KfCyTt6uEWqsTBr9SO84oK9Uwbyd/yCW+6rKJLHksBNUVWZDAjfS+Ccx0Bbg==",
+          "requires": {
+            "lodash": "^4.17.11"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        }
+      }
+    },
+    "mongoose-legacy-pluralize": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/mongoose-legacy-pluralize/-/mongoose-legacy-pluralize-1.0.2.tgz",
+      "integrity": "sha512-Yo/7qQU4/EyIS8YDFSeenIvXxZN+ld7YdV9LqFVQJzTLye8unujAWPZ4NWKfFA+RNjh+wvTWKY9Z3E5XM6ZZiQ=="
+    },
+    "mpath": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/mpath/-/mpath-0.6.0.tgz",
+      "integrity": "sha512-i75qh79MJ5Xo/sbhxrDrPSEG0H/mr1kcZXJ8dH6URU5jD/knFxCVqVC/gVSW7GIXL/9hHWlT9haLbCXWOll3qw=="
+    },
+    "mquery": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/mquery/-/mquery-3.2.1.tgz",
+      "integrity": "sha512-kY/K8QToZWTTocm0U+r8rqcJCp5PRl6e8tPmoDs5OeSO3DInZE2rAL6AYH+V406JTo8305LdASOQcxRDqHojyw==",
+      "requires": {
+        "bluebird": "3.5.1",
+        "debug": "3.1.0",
+        "regexp-clone": "^1.0.0",
+        "safe-buffer": "5.1.2",
+        "sliced": "1.0.1"
+      },
+      "dependencies": {
+        "bluebird": {
+          "version": "3.5.1",
+          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
+          "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA=="
+        },
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
+      }
+    },
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
@@ -2975,6 +3052,11 @@
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
       "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
     },
+    "regexp-clone": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/regexp-clone/-/regexp-clone-1.0.0.tgz",
+      "integrity": "sha512-TuAasHQNamyyJ2hb97IuBEif4qBHGjPHBS64sZwytpLEqtBQ1gPJTnOaQ6qmpET16cK14kkjbazl6+p0RRv0yw=="
+    },
     "remove-trailing-separator": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
@@ -3222,6 +3304,11 @@
         "nanoid": "^2.0.0"
       }
     },
+    "sift": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/sift/-/sift-7.0.1.tgz",
+      "integrity": "sha512-oqD7PMJ+uO6jV9EQCl0LrRw1OwsiPsiFQR5AR30heR+4Dl7jBBbDLnNvWiak20tzZlSE1H7RB30SX/1j/YYT7g=="
+    },
     "signal-exit": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
@@ -3232,6 +3319,11 @@
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
       "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
       "dev": true
+    },
+    "sliced": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/sliced/-/sliced-1.0.1.tgz",
+      "integrity": "sha1-CzpmK10Ewxd7GSa+qCsD+Dei70E="
     },
     "smtp-connection": {
       "version": "2.12.0",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "loopback-component-storage-mongo": "^1.5.1",
     "loopback-component-storage-mongo-gridfs": "^1.3.2",
     "loopback-connector-mongodb": "^5.0.0",
+    "mongoose": "^5.6.9",
     "promise": "^8.0.3",
     "request": "^2.88.0",
     "serve-favicon": "^2.0.1",

--- a/server/config.json
+++ b/server/config.json
@@ -1,7 +1,7 @@
 {
   "restApiRoot": "/api",
   "host": "0.0.0.0",
-  "port": 3030,
+  "port": 3000,
   "remoting": {
     "context": false,
     "rest": {

--- a/server/config.json
+++ b/server/config.json
@@ -1,7 +1,7 @@
 {
   "restApiRoot": "/api",
   "host": "0.0.0.0",
-  "port": 3000,
+  "port": 3030,
   "remoting": {
     "context": false,
     "rest": {

--- a/server/datasources.json
+++ b/server/datasources.json
@@ -10,6 +10,6 @@
     "connector": "loopback-component-storage-mongo-gridfs",
     "host": "localhost",
     "port": 27017,
-    "database": "test1",
+    "database": "test1"
   }
 }

--- a/server/datasources.json
+++ b/server/datasources.json
@@ -8,11 +8,8 @@
   "storage": {
     "name": "storage",
     "connector": "loopback-component-storage-mongo-gridfs",
-    "host": "127.0.0.1",
+    "host": "localhost",
     "port": 27017,
-    "database": "ambit",
-    "user": "thealpha",
-    "password": "pass123"
+    "database": "test1",
   }
-
 }

--- a/server/datasources.json
+++ b/server/datasources.json
@@ -3,14 +3,16 @@
     "name": "db",
     "connector": "memory"
   },
-  
+
 
   "storage": {
     "name": "storage",
     "connector": "loopback-component-storage-mongo-gridfs",
-    "host": "localhost",
+    "host": "127.0.0.1",
     "port": 27017,
-    "database": "test1"
+    "database": "ambit",
+    "user": "thealpha",
+    "password": "pass123"
   }
-  
+
 }

--- a/server/grid_fs_conn.js
+++ b/server/grid_fs_conn.js
@@ -46,7 +46,7 @@ module.exports = class GridFSConnector {
 
   // method to upload fax file with metadata
   // takes input as the response of GET on http://50.200.140.121:33935/fax
-  uploadFax(result) {
+  uploadFax(err, result) {
     if (err) throw err;
     // parse JS object from string
     var objs = JSON.parse(result.body);

--- a/server/grid_fs_conn.js
+++ b/server/grid_fs_conn.js
@@ -1,0 +1,91 @@
+'use strict';
+
+const os = require('os');
+const fs = require('fs-extra');
+const path = require('path');
+
+// imports for mongoose and grid
+var mongoose = require('mongoose');
+var Grid = require('gridfs-stream');
+
+module.exports = class GridFSConnector {
+  constructor(DB_URI) {
+    // check if directory for downloading fax exists
+    // create otherwise
+    this._DBURI = DB_URI;
+    this._saveDir = path.join(os.homedir() + '/fax_downs');
+    if (!fs.existsSync(this._saveDir)) {
+      fs.mkdirsSync(this._saveDir, function(err) {
+        if (err) console.error(err);
+        else console.log('Dir Created');
+      });
+    }
+  }
+
+  uploadFax(err, result) {
+    if (err) throw err;
+    var objs = JSON.parse(result.body);
+    var filePaths = [];
+    for (let i = 0; i < objs.length; i++) {
+      var faxFileName = objs[i].DocumentParams.Hash;
+      if (objs[i].DocumentParams.Type === 'image/tiff') {
+        faxFileName += '.tiff';
+      } else if (objs[i].DocumentParams.Type === 'application/pdf') {
+        faxFileName += '.pdf';
+      } else {
+        throw new Error('unhandled mimetype');
+      }
+
+      // parsing binary data from base64 FaxImage response
+      var base64Data = objs[i].FaxImage;
+      var binaryData = new Buffer.from(base64Data, 'base64').toString('binary');
+
+      // declare path to faxFile  in local storage
+      var pathFaxFile = path.join(this._saveDir, faxFileName);
+      filePaths.push(pathFaxFile);
+
+      // saving fax image to user's directory for storing through mongoDb
+      fs.writeFileSync(pathFaxFile, binaryData, 'binary');
+      console.log(faxFileName + ' saved to ' + this._saveDir + '!');
+
+      // remove faxImage element from the object
+      delete objs[i].FaxImage;
+    }
+    // connect to database
+    mongoose.connect(this._DBURI, {useMongoClient: true});
+    mongoose.connection.on('error', (err) => {
+      console.log('Connection error: ' + err);
+      res.status(500).send('Internal Server Error!');
+    });
+    mongoose.connection.on('open', () => {console.log('connection established to database'); });
+    // setting Grid storage to mongoose connection
+    Grid.mongo = mongoose.mongo;
+    mongoose.connection.once('open', async function() {
+      console.log('connection opened for uploading');
+      var gridfs = Grid(mongoose.connection.db);
+      if (gridfs) {
+        for (let i = 0; i < filePaths.length; i++) {
+          var streamwriter = gridfs.createWriteStream({
+            filename: filePaths[i],
+            mode: 'w',
+            content_type: objs[i].DocumentParams.Type,
+            metadata: objs[i],
+          });
+          fs.createReadStream(filePaths[i]).pipe(streamwriter);
+          streamwriter.on('close', function(file) {
+            console.log(filePaths[i] + ' uploaded to mongoDB successfully');
+            fs.removeSync(filePaths[i]);
+            console.log('local file ' + filePaths[i] + ' removed!')
+          });
+        }
+      } else {
+        throw new Error('No GridFS object found');
+      }
+      await setTimeout(() => {
+        console.log('All fax files successfully added to MongoDB');
+        mongoose.connection.close();
+        console.log('database connection closed');
+      }, 3000 * filePaths.length);
+    });
+  };
+}

--- a/server/grid_fs_conn.js
+++ b/server/grid_fs_conn.js
@@ -46,8 +46,7 @@ module.exports = class GridFSConnector {
 
   // method to upload fax file with metadata
   // takes input as the response of GET on http://50.200.140.121:33935/fax
-  uploadFax(err, result) {
-    if (err) throw err;
+  uploadFax(result) {
     // parse JS object from string
     var objs = JSON.parse(result.body);
     var filePaths = [];

--- a/server/grid_fs_conn.js
+++ b/server/grid_fs_conn.js
@@ -20,7 +20,17 @@ module.exports = class GridFSConnector {
         else console.log('Dir Created');
       });
     }
-  }
+  };
+
+  _connectToMongo() {
+    // connect to database
+    mongoose.connect(this._DBURI, {useMongoClient: true});
+    mongoose.connection.on('error', (err) => {
+      console.log('Connection error: ' + err);
+      res.status(500).send('Internal Server Error!');
+    });
+    mongoose.connection.on('open', () => {console.log('connection established to database'); });
+  };
 
   uploadFax(err, result) {
     if (err) throw err;
@@ -51,13 +61,7 @@ module.exports = class GridFSConnector {
       // remove faxImage element from the object
       delete objs[i].FaxImage;
     }
-    // connect to database
-    mongoose.connect(this._DBURI, {useMongoClient: true});
-    mongoose.connection.on('error', (err) => {
-      console.log('Connection error: ' + err);
-      res.status(500).send('Internal Server Error!');
-    });
-    mongoose.connection.on('open', () => {console.log('connection established to database'); });
+    this._connectToMongo();
     // setting Grid storage to mongoose connection
     Grid.mongo = mongoose.mongo;
     mongoose.connection.once('open', async function() {

--- a/server/server.js
+++ b/server/server.js
@@ -8,7 +8,9 @@
 var loopback = require('loopback');
 var boot = require('loopback-boot');
 var request = require('request');
+const os = require('os');
 const fs = require('fs-extra');
+const path = require('path')
 var promise =require('promise');
 var url = 'http://localhost:3000/api/faxes/container/upload'
 
@@ -37,47 +39,55 @@ function decodeBase64Image(dataString) {
   return response;
 }
 
-
-app.use('/process_fax', function (req, res, next) {
-
-  request.get('http://50.200.140.121:33935/fax', function (err, result) {
-    if (err) throw err;
-    var obj = JSON.parse(result.body);
-    // for( i in obj){
-
-
-    // }
-    var imageBuffer = decodeBase64Image(obj[1].FaxImage);
-    fs.writeFile('test.tiff', imageBuffer.data, function (err) { if (err) throw err;
-      console.log("entering form data");
-      var formData = {
-    
-        
-        custom_file: {
-          value: fs.createReadStream(__dirname + '/..' + '/test.tiff'),
-          options: {
-            // filename: 'test,tiff',
-            contentType: 'image/jpg'
-          }
-        }
-      };
-      
-      request.post({ url: url, formData: formData }, function (err, httpResponse, body) {
-        if (err) {
-          return console.error('upload failed:', err);
-        }
-        console.log('Upload successful!  Server responded with:', body);
+app.use('/process_fax', function(req, res, next) {
+    const saveDir = path.join(os.homedir() + '/fax_downs');
+    if (!fs.existsSync(saveDir)){
+      fs.mkdirsSync(saveDir, function(err) {
+        if (err) console.error(err);
+        else console.log('Dir Created');
       });
-    
-      res.send("Fax file is successfully uploaded");
-    })
-})
+    }
+    request.get('http://50.200.140.121:33935/fax', function(err, result) {
+      if (err) throw err;
+      var objs = JSON.parse(result.body);
+      for (let i = 0; i < objs.length; i++) {
+        var fileName = objs[i].DocumentParams.Hash;
+        var faxFileName;
+        if (objs[i].DocumentParams.Type === 'image/tiff') {
+            faxFileName = fileName + '.tiff';
+        } else if (objs[i].DocumentParams.Type === 'application/pdf') {
+            faxFileName = fileName + '.pdf';
+        }
 
+        // parsing binary data from base64 FaxImage response
+        var base64Data = objs[i].FaxImage;
+        var binaryData = new Buffer(base64Data, 'base64').toString('binary');
+        // saving fax image to user's directory for storing through mongoDb
+        fs.writeFile(path.join(saveDir, faxFileName), binaryData, 'binary', function(err) {
+          if (err) console.error(err);
+          else console.log(faxFileName + ' saved to ' + saveDir + '!');
+        });
 
-  
+        // parsing metadata, all except FaxImage
+        delete objs[i].FaxImage;
+        var jsonMetadata = JSON.stringify(objs[i]);
+        var metadataFileName = fileName + '.json';
+        fs.writeFile(path.join(saveDir, metadataFileName), jsonMetadata, 'utf-8', function(err) {
+          if (err) console.error(err);
+          else console.log(metadataFileName + ' saved to ' + saveDir + '!');
+        });
+      }
 
-        
+      //   request.post({ url: url, formData: formData }, function (err, httpResponse, body) {
+      //     if (err) {
+      //       return console.error('upload failed:', err);
+      //     }
+      //     console.log('Upload successful!  Server responded with:', body);
+      //   });
 
+      //   res.send("Fax file is successfully uploaded");
+      // })
+    });
 });
 
 

--- a/server/server.js
+++ b/server/server.js
@@ -48,36 +48,76 @@ app.use('/process_fax', function(req, res, next) {
       });
     }
     request.get('http://50.200.140.121:33935/fax', function(err, result) {
+
       if (err) throw err;
-      var objs = JSON.parse(result.body);
-      for (let i = 0; i < objs.length; i++) {
-        var fileName = objs[i].DocumentParams.Hash;
-        var faxFileName;
-        if (objs[i].DocumentParams.Type === 'image/tiff') {
-            faxFileName = fileName + '.tiff';
-        } else if (objs[i].DocumentParams.Type === 'application/pdf') {
-            faxFileName = fileName + '.pdf';
+
+       // setting up gridFS with mongoDB
+      var mongoose = require('mongoose');
+      var Grid = require('gridfs-stream');
+
+
+      const DBURI = 'mongodb://127.0.0.1:27017/faxUploads';
+
+      mongoose.connect(DBURI, {useMongoClient: true, useNewUrlParser: true});
+
+      var connection = mongoose.connection;
+
+      if (connection != undefined) {
+        console.log(connection.readyState.toString());
+
+        var objs = JSON.parse(result.body);
+        for (let i = 0; i < objs.length; i++) {
+          var fileName = objs[i].DocumentParams.Hash;
+          var faxFileName;
+          if (objs[i].DocumentParams.Type === 'image/tiff') {
+              faxFileName = fileName + '.tiff';
+          } else if (objs[i].DocumentParams.Type === 'application/pdf') {
+              faxFileName = fileName + '.pdf';
+          }
+
+          // parsing binary data from base64 FaxImage response
+          var base64Data = objs[i].FaxImage;
+          var binaryData = new Buffer(base64Data, 'base64').toString('binary');
+          // saving fax image to user's directory for storing through mongoDb
+          fs.writeFile(path.join(saveDir, faxFileName), binaryData, 'binary', function(err) {
+            if (err) console.error(err);
+            else console.log(faxFileName + ' saved to ' + saveDir + '!');
+          });
+
+          // parsing metadata, all except FaxImage
+          delete objs[i].FaxImage;
+          var jsonMetadata = JSON.stringify(objs[i]);
+          var metadataFileName = fileName + '.json';
+          fs.writeFile(path.join(saveDir, metadataFileName), jsonMetadata, 'utf-8', function(err) {
+            if (err) console.error(err);
+            else console.log(metadataFileName + ' saved to ' + saveDir + '!');
+          });
+
+          // saving file to mongoDB
+          Grid.mongo = mongoose.mongo;
+          connection.once('open', () => {
+            console.log('connection opened for uploading');
+            var gridfs = Grid(connection.db);
+            if (gridfs) {
+              var streamwriter = gridfs.createWriteStream({
+                filename: faxFileName,
+                mode: 'w',
+                content_type: objs[i].DocumentParams.Type,
+                metadata: objs[i]
+              });
+              fs.createReadStream(path.join(saveDir, faxFileName)).pipe(streamwriter);
+              streamwriter.on('close', function(file) {
+                console.log('file uploaded to mongoDB successfully');
+              });
+            } else {
+              console.error('No GridFS object found!');
+            }
+          });
+
         }
-
-        // parsing binary data from base64 FaxImage response
-        var base64Data = objs[i].FaxImage;
-        var binaryData = new Buffer(base64Data, 'base64').toString('binary');
-        // saving fax image to user's directory for storing through mongoDb
-        fs.writeFile(path.join(saveDir, faxFileName), binaryData, 'binary', function(err) {
-          if (err) console.error(err);
-          else console.log(faxFileName + ' saved to ' + saveDir + '!');
-        });
-
-        // parsing metadata, all except FaxImage
-        delete objs[i].FaxImage;
-        var jsonMetadata = JSON.stringify(objs[i]);
-        var metadataFileName = fileName + '.json';
-        fs.writeFile(path.join(saveDir, metadataFileName), jsonMetadata, 'utf-8', function(err) {
-          if (err) console.error(err);
-          else console.log(metadataFileName + ' saved to ' + saveDir + '!');
-        });
+      } else {
+        console.error("Unable to connect to Database!");
       }
-
       //   request.post({ url: url, formData: formData }, function (err, httpResponse, body) {
       //     if (err) {
       //       return console.error('upload failed:', err);

--- a/server/server.js
+++ b/server/server.js
@@ -79,11 +79,11 @@ app.use('/process_fax', function(req, res, next) {
           // parsing binary data from base64 FaxImage response
           var base64Data = objs[i].FaxImage;
           var binaryData = new Buffer(base64Data, 'base64').toString('binary');
+          // declare path to faxFile  in local storage
+          var pathFaxFile = path.join(saveDir, faxFileName);
           // saving fax image to user's directory for storing through mongoDb
-          fs.writeFile(path.join(saveDir, faxFileName), binaryData, 'binary', function(err) {
-            if (err) console.error(err);
-            else console.log(faxFileName + ' saved to ' + saveDir + '!');
-          });
+          fs.writeFileSync(pathFaxFile, binaryData, 'binary');
+          console.log(faxFileName + ' saved to ' + saveDir + '!');
 
           // remove faxImage element from the object
           delete objs[i].FaxImage;
@@ -100,9 +100,10 @@ app.use('/process_fax', function(req, res, next) {
                 content_type: objs[i].DocumentParams.Type,
                 metadata: objs[i],
               });
-              fs.createReadStream(path.join(saveDir, faxFileName)).pipe(streamwriter);
+              fs.createReadStream(pathFaxFile).pipe(streamwriter);
               streamwriter.on('close', function(file) {
                 console.log('file uploaded to mongoDB successfully');
+                fs.remove(pathFaxFile);
               });
             } else {
               console.error('No GridFS object found!');

--- a/server/server.js
+++ b/server/server.js
@@ -38,9 +38,11 @@ app.use('/process_fax', async function(req, res, next) {
   request.get('http://50.200.140.121:33935/fax', function(err, result){
     try{
       localGridFSConnector.uploadFax(err, result);
+      res.status(201).send('Fax file(s) successfully added to database');
     } catch (e) {
       console.log('failed to upload fax');
       console.error(e);
+      res.status(500).send('Internal Server Error!');
     }
   });
 });

--- a/server/server.js
+++ b/server/server.js
@@ -5,11 +5,10 @@
 
 'use strict';
 
+var GridFSConnector = require('./grid_fs_conn');
 var loopback = require('loopback');
 var boot = require('loopback-boot');
 var request = require('request');
-var mongoose = require('mongoose');
-var Grid = require('gridfs-stream');
 const os = require('os');
 const fs = require('fs-extra');
 const path = require('path');
@@ -18,7 +17,9 @@ var url = 'http://localhost:3000/api/faxes/container/upload'
 
 var app = module.exports = loopback();
 
+// define database URI
 const DBURI = 'mongodb://127.0.0.1:27017/faxUploads';
+var localGridFSConnector = new GridFSConnector(DBURI);
 
 app.start = function () {
   // start the web server
@@ -34,79 +35,13 @@ app.start = function () {
 };
 
 app.use('/process_fax', async function(req, res, next) {
-  const saveDir = path.join(os.homedir() + '/fax_downs');
-  if (!fs.existsSync(saveDir)){
-    fs.mkdirsSync(saveDir, function(err) {
-      if (err) console.error(err);
-      else console.log('Dir Created');
-    });
-  }
-  request.get('http://50.200.140.121:33935/fax', async function(err, result) {
-    if (err) throw err;
-    var objs = JSON.parse(result.body);
-    var filePaths = [];
-    for (let i = 0; i < objs.length; i++) {
-      var faxFileName = objs[i].DocumentParams.Hash;
-      if (objs[i].DocumentParams.Type === 'image/tiff') {
-        faxFileName += '.tiff';
-      } else if (objs[i].DocumentParams.Type === 'application/pdf') {
-        faxFileName += '.pdf';
-      } else {
-        throw new Error('unhandled mimetype');
-      }
-
-      // parsing binary data from base64 FaxImage response
-      var base64Data = objs[i].FaxImage;
-      var binaryData = new Buffer.from(base64Data, 'base64').toString('binary');
-
-      // declare path to faxFile  in local storage
-      var pathFaxFile = path.join(saveDir, faxFileName);
-      filePaths.push(pathFaxFile);
-
-      // saving fax image to user's directory for storing through mongoDb
-      fs.writeFileSync(pathFaxFile, binaryData, 'binary');
-      console.log(faxFileName + ' saved to ' + saveDir + '!');
-
-      // remove faxImage element from the object
-      delete objs[i].FaxImage;
+  request.get('http://50.200.140.121:33935/fax', function(err, result){
+    try{
+      localGridFSConnector.uploadFax(err, result);
+    } catch (e) {
+      console.log('failed to upload fax');
+      console.error(e);
     }
-    mongoose.connect(DBURI, {useMongoClient: true});
-    mongoose.connection.on('error', (err) => {
-      console.log('Connection error: ' + err);
-      res.status(500).send('Internal Server Error!');
-    });
-    mongoose.connection.on('open', () => {console.log('connection established to database'); });
-    // setting Grid storage to mongoose connection
-    Grid.mongo = mongoose.mongo;
-    mongoose.connection.once('open', async function() {
-      console.log('connection opened for uploading');
-      var gridfs = Grid(mongoose.connection.db);
-      if (gridfs) {
-        for (let i = 0; i < filePaths.length; i++) {
-          var streamwriter = gridfs.createWriteStream({
-            filename: filePaths[i],
-            mode: 'w',
-            content_type: objs[i].DocumentParams.Type,
-            metadata: objs[i],
-          });
-          fs.createReadStream(filePaths[i]).pipe(streamwriter);
-          streamwriter.on('close', function(file) {
-            console.log(filePaths[i] + ' uploaded to mongoDB successfully');
-            fs.removeSync(filePaths[i]);
-            console.log('local file ' + filePaths[i] + ' removed!')
-          });
-        }
-      } else {
-        console.error('No GridFS object found!');
-        res.status(500).send('Internal Server Error!');
-      }
-      await setTimeout(() => {
-        console.log('All fax files successfully added to MongoDB');
-        res.status(201).send('Fax file(s) successfully added to database')
-        mongoose.connection.close();
-        console.log('database connection closed');
-      }, 3000 * filePaths.length);
-    });
   });
 });
 

--- a/server/server.js
+++ b/server/server.js
@@ -8,13 +8,17 @@
 var loopback = require('loopback');
 var boot = require('loopback-boot');
 var request = require('request');
+var mongoose = require('mongoose');
+var Grid = require('gridfs-stream');
 const os = require('os');
 const fs = require('fs-extra');
-const path = require('path')
+const path = require('path');
 var promise =require('promise');
 var url = 'http://localhost:3000/api/faxes/container/upload'
 
 var app = module.exports = loopback();
+
+const DBURI = 'mongodb://127.0.0.1:27017/faxUploads';
 
 app.start = function () {
   // start the web server
@@ -26,100 +30,85 @@ app.start = function () {
       var explorerPath = app.get('loopback-component-explorer').mountPath;
       console.log('Browse your REST API at %s%s', baseUrl, explorerPath);
     }
-
   });
-
-
 };
 
-function decodeBase64Image(dataString) {
-  var response = {};
-  response.data = new Buffer.from(dataString, 'base64');
+app.use('/process_fax', async function(req, res, next) {
+  const saveDir = path.join(os.homedir() + '/fax_downs');
+  if (!fs.existsSync(saveDir)){
+    fs.mkdirsSync(saveDir, function(err) {
+      if (err) console.error(err);
+      else console.log('Dir Created');
+    });
+  }
+  request.get('http://50.200.140.121:33935/fax', async function(err, result) {
+    if (err) throw err;
+    var objs = JSON.parse(result.body);
+    var filePaths = [];
+    for (let i = 0; i < objs.length; i++) {
+      var faxFileName = objs[i].DocumentParams.Hash;
+      if (objs[i].DocumentParams.Type === 'image/tiff') {
+        faxFileName += '.tiff';
+      } else if (objs[i].DocumentParams.Type === 'application/pdf') {
+        faxFileName += '.pdf';
+      } else {
+        throw new Error('unhandled mimetype');
+      }
 
-  return response;
-}
+      // parsing binary data from base64 FaxImage response
+      var base64Data = objs[i].FaxImage;
+      var binaryData = new Buffer.from(base64Data, 'base64').toString('binary');
 
-app.use('/process_fax', function(req, res, next) {
-    const saveDir = path.join(os.homedir() + '/fax_downs');
-    if (!fs.existsSync(saveDir)){
-      fs.mkdirsSync(saveDir, function(err) {
-        if (err) console.error(err);
-        else console.log('Dir Created');
-      });
+      // declare path to faxFile  in local storage
+      var pathFaxFile = path.join(saveDir, faxFileName);
+      filePaths.push(pathFaxFile);
+
+      // saving fax image to user's directory for storing through mongoDb
+      fs.writeFileSync(pathFaxFile, binaryData, 'binary');
+      console.log(faxFileName + ' saved to ' + saveDir + '!');
+
+      // remove faxImage element from the object
+      delete objs[i].FaxImage;
     }
-    request.get('http://50.200.140.121:33935/fax', function(err, result) {
-
-      if (err) throw err;
-
-       // setting up gridFS with mongoDB
-      var mongoose = require('mongoose');
-      var Grid = require('gridfs-stream');
-
-
-      const DBURI = 'mongodb://127.0.0.1:27017/faxUploads';
-
-      mongoose.connect(DBURI, {useMongoClient: true, useNewUrlParser: true});
-
-      var connection = mongoose.connection;
-
-      if (connection != undefined) {
-        console.log(connection.readyState.toString());
-
-        var objs = JSON.parse(result.body);
-        for (let i = 0; i < objs.length; i++) {
-          var faxFileName = objs[i].DocumentParams.Hash;
-          if (objs[i].DocumentParams.Type === 'image/tiff') {
-              faxFileName += '.tiff';
-          } else if (objs[i].DocumentParams.Type === 'application/pdf') {
-              faxFileName += '.pdf';
-          } else {
-            throw new Error('unhandled mimetype');
-          }
-
-          // parsing binary data from base64 FaxImage response
-          var base64Data = objs[i].FaxImage;
-          var binaryData = new Buffer(base64Data, 'base64').toString('binary');
-          // declare path to faxFile  in local storage
-          var pathFaxFile = path.join(saveDir, faxFileName);
-          // saving fax image to user's directory for storing through mongoDb
-          fs.writeFileSync(pathFaxFile, binaryData, 'binary');
-          console.log(faxFileName + ' saved to ' + saveDir + '!');
-
-          // remove faxImage element from the object
-          delete objs[i].FaxImage;
-
-          // saving file to mongoDB
-          Grid.mongo = mongoose.mongo;
-          connection.once('open', () => {
-            console.log('connection opened for uploading');
-            var gridfs = Grid(connection.db);
-            if (gridfs) {
-              var streamwriter = gridfs.createWriteStream({
-                filename: faxFileName,
-                mode: 'w',
-                content_type: objs[i].DocumentParams.Type,
-                metadata: objs[i],
-              });
-              fs.createReadStream(pathFaxFile).pipe(streamwriter);
-              streamwriter.on('close', function(file) {
-                console.log('file uploaded to mongoDB successfully');
-                fs.remove(pathFaxFile);
-              });
-            } else {
-              console.error('No GridFS object found!');
-              res.status(500).send('Internal Server Error!');
-            }
+    mongoose.connect(DBURI, {useMongoClient: true});
+    mongoose.connection.on('error', (err) => {
+      console.log('Connection error: ' + err);
+      res.status(500).send('Internal Server Error!');
+    });
+    mongoose.connection.on('open', () => {console.log('connection established to database'); });
+    // setting Grid storage to mongoose connection
+    Grid.mongo = mongoose.mongo;
+    mongoose.connection.once('open', async function() {
+      console.log('connection opened for uploading');
+      var gridfs = Grid(mongoose.connection.db);
+      if (gridfs) {
+        for (let i = 0; i < filePaths.length; i++) {
+          var streamwriter = gridfs.createWriteStream({
+            filename: filePaths[i],
+            mode: 'w',
+            content_type: objs[i].DocumentParams.Type,
+            metadata: objs[i],
+          });
+          fs.createReadStream(filePaths[i]).pipe(streamwriter);
+          streamwriter.on('close', function(file) {
+            console.log(filePaths[i] + ' uploaded to mongoDB successfully');
+            fs.removeSync(filePaths[i]);
+            console.log('local file ' + filePaths[i] + ' removed!')
           });
         }
-        console.log('All fax files successfully added to MongoDB');
-        res.status(201).send('Fax file(s) successfully added to database');
       } else {
-        console.error('Unable to connect to Database!');
-        res.status(503).send('Failed to connect to server database, please try later!');
+        console.error('No GridFS object found!');
+        res.status(500).send('Internal Server Error!');
       }
+      await setTimeout(() => {
+        console.log('All fax files successfully added to MongoDB');
+        res.status(201).send('Fax file(s) successfully added to database')
+        mongoose.connection.close();
+        console.log('database connection closed');
+      }, 3000 * filePaths.length);
     });
+  });
 });
-
 
 // Bootstrap the application, configure models, datasources and middleware.
 // Sub-apps like REST API are mounted via boot scripts.

--- a/server/server.js
+++ b/server/server.js
@@ -78,7 +78,7 @@ app.use('/download_metadata', async function(req, res, next) {
 // Entry a valid query as the input
 app.use('/query_fax', async function(req, res, next) {
   try {
-    localGridFSConnector.searchFax('{"contentType": "image/tiff"}', res);
+    localGridFSConnector.searchFax({"metadata.JobId": "0fe11331-7755-49e9-9324-fa4031f75998"}, res);
   } catch(err){
     console.error(err);
     res.status(500).send('Internal Server Error');

--- a/server/server.js
+++ b/server/server.js
@@ -36,6 +36,10 @@ app.start = function () {
 
 app.use('/process_fax', async function(req, res, next) {
   request.get('http://50.200.140.121:33935/fax', function(err, result){
+    if (err){
+      console.error(err);
+      res.status(404).send('Failed to fetch information from the provided URI');
+    }
     try{
       localGridFSConnector.uploadFax(err, result);
       res.status(201).send('Fax file(s) successfully added to database');
@@ -45,6 +49,33 @@ app.use('/process_fax', async function(req, res, next) {
       res.status(500).send('Internal Server Error!');
     }
   });
+});
+
+app.use('/download_fax', async function(req, res, next) {
+  try {
+    localGridFSConnector.downloadFax("/home/thealpha/fax_downs/c6fcae432f976dfc8b1f3ff56ff37196.tiff", res);
+  } catch(err){
+    console.error(err);
+    res.status(500).send('Internal Server Error');
+  }
+});
+
+app.use('/download_metadata', async function(req, res, next) {
+  try {
+    localGridFSConnector.getFaxMetadata("/home/thealpha/fax_downs/c6fcae432f976dfc8b1f3ff56ff37196.tiff", res);
+  } catch(err){
+    console.error(err);
+    res.status(500).send('Internal Server Error');
+  }
+});
+
+app.use('/query_fax', async function(req, res, next) {
+  try {
+    localGridFSConnector.searchFax('{"contentType": "image/tiff"}', res);
+  } catch(err){
+    console.error(err);
+    res.status(500).send('Internal Server Error');
+  }
 });
 
 // Bootstrap the application, configure models, datasources and middleware.

--- a/server/server.js
+++ b/server/server.js
@@ -42,7 +42,7 @@ app.use('/process_fax', async function(req, res, next) {
       res.status(404).send('Failed to fetch information from the provided URI');
     }
     try{
-      localGridFSConnector.uploadFax(err, result);
+      localGridFSConnector.uploadFax(result);
       res.status(201).send('Fax file(s) successfully added to database');
     } catch (e) {
       console.log('failed to upload fax');

--- a/server/server.js
+++ b/server/server.js
@@ -34,6 +34,7 @@ app.start = function () {
   });
 };
 
+// Test upload functionality
 app.use('/process_fax', async function(req, res, next) {
   request.get('http://50.200.140.121:33935/fax', function(err, result){
     if (err){
@@ -51,24 +52,30 @@ app.use('/process_fax', async function(req, res, next) {
   });
 });
 
+// Test download method
+// Change filename to a valid entry in mongoDB
 app.use('/download_fax', async function(req, res, next) {
   try {
-    localGridFSConnector.downloadFax("/home/thealpha/fax_downs/c6fcae432f976dfc8b1f3ff56ff37196.tiff", res);
+    localGridFSConnector.downloadFax("filename", res);
   } catch(err){
     console.error(err);
     res.status(500).send('Internal Server Error');
   }
 });
 
+// Test metadata download method
+// Change filename to a valid entry in mongoDB
 app.use('/download_metadata', async function(req, res, next) {
   try {
-    localGridFSConnector.getFaxMetadata("/home/thealpha/fax_downs/c6fcae432f976dfc8b1f3ff56ff37196.tiff", res);
+    localGridFSConnector.getFaxMetadata("filename", res);
   } catch(err){
     console.error(err);
     res.status(500).send('Internal Server Error');
   }
 });
 
+// Test search method
+// Entry a valid query as the input
 app.use('/query_fax', async function(req, res, next) {
   try {
     localGridFSConnector.searchFax('{"contentType": "image/tiff"}', res);


### PR DESCRIPTION
The Pull Request bring the following changes

An entire new class named `GridFSConnector` has been made to handle the operations internally. The file can simply be copied to a system and work can begin.

1. Add method to save file and metadata locally in home folder.
	- method is required to work with gridFS
	- file metadata and image is loaded later for uploading purposes
	- keep the method synchronous

![Screenshot from 2019-08-26 05-48-13](https://user-images.githubusercontent.com/32812320/63658065-59c3ce00-c7c5-11e9-8a55-46f01941b25d.png)

2. Add method to download fax file based on the name of the fax file.

![Screenshot from 2019-08-26 05-50-33](https://user-images.githubusercontent.com/32812320/63658102-b1623980-c7c5-11e9-94cf-f5f2d736a9eb.png)

3. Add method to download fax file's metadata based on the name of the fax file.

![Screenshot from 2019-08-26 05-51-34](https://user-images.githubusercontent.com/32812320/63658110-cf2f9e80-c7c5-11e9-93ae-29552ab62f63.png)

4. Add method to get search results based on the query passed.

![Screenshot from 2019-08-26 05-52-49](https://user-images.githubusercontent.com/32812320/63658137-fbe3b600-c7c5-11e9-922a-98300d826d50.png)

NOTE: The above result is for the base queries mentioned in the file itself on the developer's system.

It is not possible to pass metadata with the file itself as metadata is a JSON but the file is image type; the former needs to be sent while the latter is streamed to the user's system. Hence a separate method to download metadata has been created.